### PR TITLE
Remove Errors surrounding characters like "*"

### DIFF
--- a/src/VideoConverter.js
+++ b/src/VideoConverter.js
@@ -86,7 +86,7 @@ VideoConverter.setFfmpegPath = ffmpeg.setFfmpegPath;
  * @returns {string}
  */
 function scale(width, height) {
-    return "scale=iw*min(" + width + "/iw\\," + height + "/ih):ih*min(" + width + "/iw\\," + height + "/ih)";
+    return "scale=\"iw*min(" + width + "/iw\\," + height + "/ih):ih*min(" + width + "/iw\\," + height + "/ih)\"";
 }
 
 /**


### PR DESCRIPTION
in zsh you get an error `zsh: unknown file attribute: 2` because of not having * in quotes